### PR TITLE
Fix/set response after handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Set last HTTP response/request methods less strict with param values. Sets empty value if supplied with invalid value.
 
 ## [1.0.4] - 2020-02-25
 - Removed unused includes in OnPayAPI class (PR #20)

--- a/src/OnPayAPI.php
+++ b/src/OnPayAPI.php
@@ -308,24 +308,28 @@ class OnPayAPI {
     }
 
     /**
-     * @param Request $request
+     * @param mixed $request
      */
-    private function setLastHttpRequest(Request $request) {
+    private function setLastHttpRequest($request) {
         $httpRequest = new HttpRequest();
-        $httpRequest->setMethod($request->getMethod());
-        $httpRequest->setUri($request->getUri());
-        $httpRequest->setHeaders($request->getHeaders());
-        $httpRequest->setBody($request->getBody());
+        if ($request instanceof Request) {
+            $httpRequest->setMethod($request->getMethod());
+            $httpRequest->setUri($request->getUri());
+            $httpRequest->setHeaders($request->getHeaders());
+            $httpRequest->setBody($request->getBody());
+        }
         $this->request = $httpRequest;
     }
 
     /**
-     * @param Response $response
+     * @param mixed $response
      */
-    private function setLastHttpResponse(Response $response) {
+    private function setLastHttpResponse($response) {
         $httpResponse = new HttpResponse();
-        $httpResponse->setStatusCode($response->getStatusCode());
-        $httpResponse->setBody($response->getBody());
+        if ($response instanceof Response) {
+            $httpResponse->setStatusCode($response->getStatusCode());
+            $httpResponse->setBody($response->getBody());
+        }
         $this->response = $httpResponse;
     }
 


### PR DESCRIPTION
When setting the last http response value in OnPayAPI class, we handle the response first, before trying to set the value, incase the oauth client resturns false.