### PR TITLE
Also handle if the token format is completely broken.

### DIFF
--- a/src/OnPayAPI.php
+++ b/src/OnPayAPI.php
@@ -226,6 +226,8 @@ class OnPayAPI {
             throw new ConnectionException($e->getMessage(), $e->getCode(), $e);
         } catch (\fkooman\OAuth\Client\Exception\TokenException $e) {
             throw new TokenException($e->getMessage(), $e->getCode(), $e);
+        } catch (\fkooman\OAUth\Client\Exception\AccessTokenException $e) {
+            throw new TokenException($e->getMessage(), $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
There was an exception from the OAUTH token handling we did not catch, and wrap correctly.