### PR TITLE
Handle json_decode() failing due to invalid body data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Throw an ApiException with a meaningful error message when response json body fails to decode.
 
 ## [1.0.16] - 2021-01-28
 - When no redirect_uri value is sent to OnPayAPI, add an empty value to the option.

--- a/src/OnPayAPI.php
+++ b/src/OnPayAPI.php
@@ -303,6 +303,9 @@ class OnPayAPI {
         $message = '';
         if ('' !== $response->getBody() && null !== $response->getBody()) {
             $body = json_decode($response->getBody(), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \RuntimeException('Failed to decode JSON body-response: ' . json_last_error_msg());   
+            }
             if (array_key_exists('errors', $body)) {
                 $message = $body['errors'][0]['message'];
             }

--- a/src/OnPayAPI.php
+++ b/src/OnPayAPI.php
@@ -304,7 +304,7 @@ class OnPayAPI {
         if ('' !== $response->getBody() && null !== $response->getBody()) {
             $body = json_decode($response->getBody(), true);
             if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new \RuntimeException('Failed to decode JSON body-response: ' . json_last_error_msg());   
+                throw new ApiException('Failed to decode JSON body-response: ' . json_last_error_msg(), $response->getStatusCode());   
             }
             if (array_key_exists('errors', $body)) {
                 $message = $body['errors'][0]['message'];


### PR DESCRIPTION
Make the API fail nicely if invalid JSON is returned in the response.

(Done in PHP 5.6-compat fashion)