### PR TITLE
dj/Add documentation for subscription_with_transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ $paymentWindow->setInfo($paymentInfo);
 <?php } ?>
 
 ```
+You can create a transaction automatically when creating a new subscription using the following functions for the `$paymentWindow` variable:
+```php
+$paymentWindow->setType("subscription");
+$paymentWindow->setSubscriptionWithTransaction(true);
+```
 
 Verifying a payment from the acceptment page can easily be done as following: 
 


### PR DESCRIPTION
We do not mention how to use the subscription_with_transaction function with the SDK. I have mentioned this in the readme for better clarity on this feature.