### PR TITLE
Add Currencies and Exponents to SDK

### DIFF
--- a/src/API/Util/Currencies.php
+++ b/src/API/Util/Currencies.php
@@ -2,49 +2,82 @@
 
 namespace OnPay\API\Util;
 
-use OnPay\API\Exception\ApiException;
-
 class Currencies {
-    /**
-     * Array of accepted currencies as key, exponent as value
-     */
-    const ACCEPTED_CURRENCIES = [
-        36 => 2, // AUD
-        124 => 2, // CAD
-        156 => 2, // CNY
-        203 => 2, // CZK
-        208 => 2, // DKK
-        352 => 0, // ISK - Historically was 2, but we follow the post-2017 standard
-        356 => 2, // INR
-        392 => 0, // JPY
-        554 => 2, // NZD
-        578 => 2, // NOK
-        643 => 2, // RUB
-        702 => 2, // SGD
-        710 => 2, // ZAR
-        748 => 2, // SZL
-        752 => 2, // SEK
-        756 => 2, // CHF
-        818 => 2, // EGP
-        826 => 2, // GBP
-        840 => 2, // USD
-        978 => 2, // EUR
-        980 => 2, // UAH
-        985 => 2, // PLN
-        986 => 2, // BRL
-    ];
+
+    const ALPHA3_CURRENCIES = array(
+        'AUD' => array('exponent'=>2, 'iso4217' => 36),
+        'CAD' => array('exponent'=>2, 'iso4217' => 124),
+        'CNY' => array('exponent'=>2, 'iso4217' => 156),
+        'CZK' => array('exponent'=>2, 'iso4217' => 203),
+        'DKK' => array('exponent'=>2, 'iso4217' => 208),
+        'ISK' => array('exponent'=>0, 'iso4217' => 352),
+        'INR' => array('exponent'=>2, 'iso4217' => 356),
+        'JPY' => array('exponent'=>0, 'iso4217' => 392),
+        'NZD' => array('exponent'=>2, 'iso4217' => 554),
+        'NOK' => array('exponent'=>2, 'iso4217' => 578),
+        'RUB' => array('exponent'=>2, 'iso4217' => 643),
+        'SGD' => array('exponent'=>2, 'iso4217' => 702),
+        'ZAR' => array('exponent'=>2, 'iso4217' => 710),
+        'SZL' => array('exponent'=>2, 'iso4217' => 748),
+        'SEK' => array('exponent'=>2, 'iso4217' => 752),
+        'CHF' => array('exponent'=>2, 'iso4217' => 756),
+        'ECP' => array('exponent'=>2, 'iso4217' => 818),
+        'GBP' => array('exponent'=>2, 'iso4217' => 826),
+        'USD' => array('exponent'=>2, 'iso4217' => 840),
+        'EUR' => array('exponent'=>2, 'iso4217' => 978),
+        'UAH' => array('exponent'=>2, 'iso4217' => 980),
+        'PLN' => array('exponent'=>2, 'iso4217' => 985),
+        'BRL' => array('exponent'=>2, 'iso4217' => 986),
+    );
+
+    const ISO4217_CURRENCIES = array(
+        36 =>  array('exponent'=>2, 'alpha3' => 'AUD'),
+        124 => array('exponent'=>2, 'alpha3' => 'CAD'),
+        156 => array('exponent'=>2, 'alpha3' => 'CNY'),
+        203 => array('exponent'=>2, 'alpha3' => 'CZK'),
+        208 => array('exponent'=>2, 'alpha3' => 'DKK'),
+        352 => array('exponent'=>0, 'alpha3' => 'ISK'),
+        356 => array('exponent'=>2, 'alpha3' => 'INR'),
+        392 => array('exponent'=>0, 'alpha3' => 'JPY'),
+        554 => array('exponent'=>2, 'alpha3' => 'NZD'),
+        578 => array('exponent'=>2, 'alpha3' => 'NOK'),
+        643 => array('exponent'=>2, 'alpha3' => 'RUB'),
+        702 => array('exponent'=>2, 'alpha3' => 'SGD'),
+        710 => array('exponent'=>2, 'alpha3' => 'ZAR'),
+        748 => array('exponent'=>2, 'alpha3' => 'SZL'),
+        752 => array('exponent'=>2, 'alpha3' => 'SEK'),
+        756 => array('exponent'=>2, 'alpha3' => 'CHF'),
+        818 => array('exponent'=>2, 'alpha3' => 'ECP'),
+        826 => array('exponent'=>2, 'alpha3' => 'GBP'),
+        840 => array('exponent'=>2, 'alpha3' => 'USD'),
+        978 => array('exponent'=>2, 'alpha3' => 'EUR'),
+        980 => array('exponent'=>2, 'alpha3' => 'UAH'),
+        985 => array('exponent'=>2, 'alpha3' => 'PLN'),
+        986 => array('exponent'=>2, 'alpha3' => 'BRL'),
+    );
 
     /**
-     * @param int $currencyCode
-     * @return int
-     * @throws ApiException
+     * @param int $alpha3
+     * @return bool
      */
-    public function getCurrencyExponent($currencyCode) {
-        $currencyArray = self::ACCEPTED_CURRENCIES;
-        if (!isset($currencyArray[$currencyCode])) {
-            throw new ApiException("Invalid Currency Code: $currencyCode - No exponent available.");
+    public function isValidAlpha3($alpha3) {
+        $currencyArray = self::ALPHA3_CURRENCIES;
+        if (!isset($currencyArray[$alpha3])) {
+            return false;
         }
-        return $currencyArray[$currencyCode];
+        return true;
+    }
+
+    /**
+     * @param int $iso4217
+     * @return bool
+     */
+    public function isValidISO4217($iso4217) {
+        $currencyArray = self::ISO4217_CURRENCIES;
+        if (!isset($currencyArray[$iso4217])) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/API/Util/Currencies.php
+++ b/src/API/Util/Currencies.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace OnPay\API\Util;
+
+use OnPay\API\Exception\ApiException;
+
+class Currencies {
+    /**
+     * Array of accepted currencies as key, exponent as value
+     */
+    const ACCEPTED_CURRENCIES = [
+        36 => 2, // AUD
+        124 => 2, // CAD
+        156 => 2, // CNY
+        203 => 2, // CZK
+        208 => 2, // DKK
+        352 => 0, // ISK - Historically was 2, but we follow the post-2017 standard
+        356 => 2, // INR
+        392 => 0, // JPY
+        554 => 2, // NZD
+        578 => 2, // NOK
+        643 => 2, // RUB
+        702 => 2, // SGD
+        710 => 2, // ZAR
+        748 => 2, // SZL
+        752 => 2, // SEK
+        756 => 2, // CHF
+        818 => 2, // EGP
+        826 => 2, // GBP
+        840 => 2, // USD
+        978 => 2, // EUR
+        980 => 2, // UAH
+        985 => 2, // PLN
+        986 => 2, // BRL
+    ];
+
+    /**
+     * @param int $currencyCode
+     * @return int
+     * @throws ApiException
+     */
+    public function getCurrencyExponent($currencyCode) {
+        $currencyArray = self::ACCEPTED_CURRENCIES;
+        if (!isset($currencyArray[$currencyCode])) {
+            throw new ApiException("Invalid Currency Code: $currencyCode - No exponent available.");
+        }
+        return $currencyArray[$currencyCode];
+    }
+
+}

--- a/src/API/Util/Currencies.php
+++ b/src/API/Util/Currencies.php
@@ -4,80 +4,60 @@ namespace OnPay\API\Util;
 
 class Currencies {
 
-    const ALPHA3_CURRENCIES = array(
-        'AUD' => array('exponent'=>2, 'iso4217' => 36),
-        'CAD' => array('exponent'=>2, 'iso4217' => 124),
-        'CNY' => array('exponent'=>2, 'iso4217' => 156),
-        'CZK' => array('exponent'=>2, 'iso4217' => 203),
-        'DKK' => array('exponent'=>2, 'iso4217' => 208),
-        'ISK' => array('exponent'=>0, 'iso4217' => 352),
-        'INR' => array('exponent'=>2, 'iso4217' => 356),
-        'JPY' => array('exponent'=>0, 'iso4217' => 392),
-        'NZD' => array('exponent'=>2, 'iso4217' => 554),
-        'NOK' => array('exponent'=>2, 'iso4217' => 578),
-        'RUB' => array('exponent'=>2, 'iso4217' => 643),
-        'SGD' => array('exponent'=>2, 'iso4217' => 702),
-        'ZAR' => array('exponent'=>2, 'iso4217' => 710),
-        'SZL' => array('exponent'=>2, 'iso4217' => 748),
-        'SEK' => array('exponent'=>2, 'iso4217' => 752),
-        'CHF' => array('exponent'=>2, 'iso4217' => 756),
-        'ECP' => array('exponent'=>2, 'iso4217' => 818),
-        'GBP' => array('exponent'=>2, 'iso4217' => 826),
-        'USD' => array('exponent'=>2, 'iso4217' => 840),
-        'EUR' => array('exponent'=>2, 'iso4217' => 978),
-        'UAH' => array('exponent'=>2, 'iso4217' => 980),
-        'PLN' => array('exponent'=>2, 'iso4217' => 985),
-        'BRL' => array('exponent'=>2, 'iso4217' => 986),
-    );
-
-    const ISO4217_CURRENCIES = array(
-        36 =>  array('exponent'=>2, 'alpha3' => 'AUD'),
-        124 => array('exponent'=>2, 'alpha3' => 'CAD'),
-        156 => array('exponent'=>2, 'alpha3' => 'CNY'),
-        203 => array('exponent'=>2, 'alpha3' => 'CZK'),
-        208 => array('exponent'=>2, 'alpha3' => 'DKK'),
-        352 => array('exponent'=>0, 'alpha3' => 'ISK'),
-        356 => array('exponent'=>2, 'alpha3' => 'INR'),
-        392 => array('exponent'=>0, 'alpha3' => 'JPY'),
-        554 => array('exponent'=>2, 'alpha3' => 'NZD'),
-        578 => array('exponent'=>2, 'alpha3' => 'NOK'),
-        643 => array('exponent'=>2, 'alpha3' => 'RUB'),
-        702 => array('exponent'=>2, 'alpha3' => 'SGD'),
-        710 => array('exponent'=>2, 'alpha3' => 'ZAR'),
-        748 => array('exponent'=>2, 'alpha3' => 'SZL'),
-        752 => array('exponent'=>2, 'alpha3' => 'SEK'),
-        756 => array('exponent'=>2, 'alpha3' => 'CHF'),
-        818 => array('exponent'=>2, 'alpha3' => 'ECP'),
-        826 => array('exponent'=>2, 'alpha3' => 'GBP'),
-        840 => array('exponent'=>2, 'alpha3' => 'USD'),
-        978 => array('exponent'=>2, 'alpha3' => 'EUR'),
-        980 => array('exponent'=>2, 'alpha3' => 'UAH'),
-        985 => array('exponent'=>2, 'alpha3' => 'PLN'),
-        986 => array('exponent'=>2, 'alpha3' => 'BRL'),
-    );
+    /**
+     * This array contains all the supported currencies and is based on the following documentation:
+     * https://onpay.io/docs/technical/index.html#accepted-currencies
+     */
+    const CURRENCIES = [
+        'AUD' => ['exponent' => 2, 'ISO4217' => 36],
+        'CAD' => ['exponent' => 2, 'ISO4217' => 124],
+        'CNY' => ['exponent' => 2, 'ISO4217' => 156],
+        'CZK' => ['exponent' => 2, 'ISO4217' => 203],
+        'DKK' => ['exponent' => 2, 'ISO4217' => 208],
+        'ISK' => ['exponent' => 0, 'ISO4217' => 352],
+        'INR' => ['exponent' => 2, 'ISO4217' => 356],
+        'JPY' => ['exponent' => 0, 'ISO4217' => 392],
+        'NZD' => ['exponent' => 2, 'ISO4217' => 554],
+        'NOK' => ['exponent' => 2, 'ISO4217' => 578],
+        'RUB' => ['exponent' => 2, 'ISO4217' => 643],
+        'SGD' => ['exponent' => 2, 'ISO4217' => 702],
+        'ZAR' => ['exponent' => 2, 'ISO4217' => 710],
+        'SZL' => ['exponent' => 2, 'ISO4217' => 748],
+        'SEK' => ['exponent' => 2, 'ISO4217' => 752],
+        'CHF' => ['exponent' => 2, 'ISO4217' => 756],
+        'EGP' => ['exponent' => 2, 'ISO4217' => 818],
+        'GBP' => ['exponent' => 2, 'ISO4217' => 826],
+        'USD' => ['exponent' => 2, 'ISO4217' => 840],
+        'EUR' => ['exponent' => 2, 'ISO4217' => 978],
+        'UAH' => ['exponent' => 2, 'ISO4217' => 980],
+        'PLN' => ['exponent' => 2, 'ISO4217' => 985],
+        'BRL' => ['exponent' => 2, 'ISO4217' => 986],
+    ];
 
     /**
-     * @param int $alpha3
-     * @return bool
+     * @param string $alpha3
+     * @return bool|string
      */
     public function isValidAlpha3($alpha3) {
-        $currencyArray = self::ALPHA3_CURRENCIES;
+        $currencyArray = self::CURRENCIES;
         if (!isset($currencyArray[$alpha3])) {
             return false;
         }
-        return true;
+        return $alpha3;
     }
 
     /**
-     * @param int $iso4217
-     * @return bool
+     * @param int $ISO4217
+     * @return bool|string
      */
-    public function isValidISO4217($iso4217) {
-        $currencyArray = self::ISO4217_CURRENCIES;
-        if (!isset($currencyArray[$iso4217])) {
-            return false;
+    public function isValidISO4217($ISO4217) {
+        $currencyArray = self::CURRENCIES;
+        foreach ($currencyArray as $alpha3 => $currencyData) {
+            if ($currencyData['ISO4217'] === $ISO4217) {
+                return $alpha3;
+            }
         }
-        return true;
+        return false;
     }
 
 }

--- a/src/API/Util/Currency.php
+++ b/src/API/Util/Currency.php
@@ -16,7 +16,7 @@ class Currency extends Currencies {
     /**
      * @var int
      */
-    private $iso4217;
+    private $ISO4217;
     /**
      * @var int
      */
@@ -27,15 +27,15 @@ class Currency extends Currencies {
      * @throws ApiException
      */
     public function __construct($currencyCode) {
-        if ($this->isValidAlpha3($currencyCode)) {
-            $this->alpha3 = $currencyCode;
-            $this->assignValuesFromAlpha3();
-        } elseif ($this->isValidISO4217($currencyCode)) {
-            $this->iso4217 = $currencyCode;
-            $this->assignValuesFromIso4217();
-        } else {
+        $this->alpha3 = $this->isValidAlpha3($currencyCode);
+        if (!$this->alpha3) {
+            $this->alpha3 = $this->isValidISO4217($currencyCode);
+        }
+        if (!$this->alpha3) {
             throw new ApiException("Unsupported currency provided: " . $currencyCode);
         }
+        $this->ISO4217 = self::CURRENCIES[$this->alpha3]['ISO4217'];
+        $this->exponent = self::CURRENCIES[$this->alpha3]['exponent'];
     }
 
     /**
@@ -56,16 +56,7 @@ class Currency extends Currencies {
      * @return int
      */
     public function getISO4217() {
-        return $this->iso4217;
+        return $this->ISO4217;
     }
 
-    private function assignValuesFromAlpha3() {
-        $this->iso4217 = self::ALPHA3_CURRENCIES[$this->alpha3]['iso4217'];
-        $this->exponent = self::ALPHA3_CURRENCIES[$this->alpha3]['exponent'];
-    }
-
-    private function assignValuesFromIso4217() {
-        $this->alpha3 = self::ISO4217_CURRENCIES[$this->iso4217]['alpha3'];
-        $this->exponent = self::ISO4217_CURRENCIES[$this->iso4217]['exponent'];
-    }
 }

--- a/src/API/Util/Currency.php
+++ b/src/API/Util/Currency.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace OnPay\API\Util;
+
+use OnPay\API\Exception\ApiException;
+
+/**
+ * This currency helper class will assist with ensuring currencies used are supported and in the correct format
+ */
+class Currency extends Currencies {
+
+    /**
+     * @var string
+     */
+    private $alpha3;
+    /**
+     * @var int
+     */
+    private $iso4217;
+    /**
+     * @var int
+     */
+    private $exponent;
+
+    /**
+     * @param string|int $currencyCode This can be either a valid ISO4217 value or a valid Alpha3 value.
+     * @throws ApiException
+     */
+    public function __construct($currencyCode) {
+        if ($this->isValidAlpha3($currencyCode)) {
+            $this->alpha3 = $currencyCode;
+            $this->assignValuesFromAlpha3();
+        } elseif ($this->isValidISO4217($currencyCode)) {
+            $this->iso4217 = $currencyCode;
+            $this->assignValuesFromIso4217();
+        } else {
+            throw new ApiException("Unsupported currency provided: " . $currencyCode);
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getExponent() {
+        return $this->exponent;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlpha3() {
+        return $this->alpha3;
+    }
+
+    /**
+     * @return int
+     */
+    public function getISO4217() {
+        return $this->iso4217;
+    }
+
+    private function assignValuesFromAlpha3() {
+        $this->iso4217 = self::ALPHA3_CURRENCIES[$this->alpha3]['iso4217'];
+        $this->exponent = self::ALPHA3_CURRENCIES[$this->alpha3]['exponent'];
+    }
+
+    private function assignValuesFromIso4217() {
+        $this->alpha3 = self::ISO4217_CURRENCIES[$this->iso4217]['alpha3'];
+        $this->exponent = self::ISO4217_CURRENCIES[$this->iso4217]['exponent'];
+    }
+}


### PR DESCRIPTION
Addition of a new Currencies class with available Currency Codes and their Exponents to assist users of the SDK in formatting currencies correctly for use with the API