### PR TITLE
Fix Notice in Magento2

### DIFF
--- a/src/OnPayAPI.php
+++ b/src/OnPayAPI.php
@@ -148,6 +148,7 @@ class OnPayAPI {
             $session->set('user_id', $this->userId);
             $session->set('redirect_uri', $this->options['redirect_uri']);
             $session->set('scope', $this->scope);
+            $session->set('code_verifier', '');
             $this->client->setSession($session);
         }
 


### PR DESCRIPTION
The variable code_verifier is not set in the static session.
This makes the OAuth2 client throw a notice, when reading the session variables.
The notice halts all further progress in Magento2 in production mode.