### PR TITLE
Ensure the HMAC is present, before trying to get it

### DIFF
--- a/src/API/PaymentWindow.php
+++ b/src/API/PaymentWindow.php
@@ -493,6 +493,10 @@ class PaymentWindow
             }
         }
 
+        if (!isset($validFields['onpay_hmac_sha1'])) {
+            return false;
+        }
+
         $verify = $validFields['onpay_hmac_sha1'];
 
         unset($validFields['onpay_hmac_sha1']);


### PR DESCRIPTION
Avoid causing a "Notice undefined index", in case a payload without a HMAC is provided.