### PR TITLE
Enable support for surcharge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add support for surcharge
 
 ## [1.0.30] - 2024-08-05
 - Allow a broader selection of characters in cartinfo account id

--- a/src/API/PaymentWindow.php
+++ b/src/API/PaymentWindow.php
@@ -584,7 +584,10 @@ class PaymentWindow
         }
     }
 
-    public function setSurchargeEnabled(bool $surcharge_enabled) {
+    /**
+    * @param bool $surcharge_enabled
+    */
+    public function setSurchargeEnabled($surcharge_enabled) {
         $this->surcharge_enabled = $surcharge_enabled;
     }
 
@@ -595,7 +598,10 @@ class PaymentWindow
         return $this->surcharge_enabled;
     }
 
-    public function setSurchargeVatRate(int $surcharge_vat_rate) {
+    /**
+    * @param int $surcharge_vat_rate
+    */
+    public function setSurchargeVatRate($surcharge_vat_rate) {
         $this->surcharge_vat_rate = $surcharge_vat_rate;
     }
 

--- a/src/API/PaymentWindow.php
+++ b/src/API/PaymentWindow.php
@@ -55,6 +55,8 @@ class PaymentWindow
      * @var Cart|null
      */
     private $cart = null;
+    private $surcharge_enabled = null;
+    private $surcharge_vat_rate = null;
     private $availableFields;
     private $requiredFields;
     private $actionUrl = "https://onpay.io/window/v3/";
@@ -82,7 +84,9 @@ class PaymentWindow
             'subscription_with_transaction',
             'website',
             'platform',
-            'expiration'
+            'expiration',
+            'surcharge_enabled',
+            'surcharge_vat_rate',
         ];
 
         $this->requiredFields = [
@@ -578,5 +582,27 @@ class PaymentWindow
         } else {
             $this->subscription_with_transaction = null;
         }
+    }
+
+    public function setSurchargeEnabled(bool $surcharge_enabled) {
+        $this->surcharge_enabled = $surcharge_enabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSurcharge_enabled() {
+        return $this->surcharge_enabled;
+    }
+
+    public function setSurchargeVatRate(int $surcharge_vat_rate) {
+        $this->surcharge_vat_rate = $surcharge_vat_rate;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSurchargeVatRate() {
+        return $this->surcharge_vat_rate;
     }
 }

--- a/src/API/Subscription/DetailedSubscription.php
+++ b/src/API/Subscription/DetailedSubscription.php
@@ -24,6 +24,7 @@ class DetailedSubscription extends SimpleSubscription
         $this->cardBin = isset($data['card_bin']) ? $data['card_bin'] : null;
         $this->ip = isset($data['ip']) ? $data['ip'] : null;
         $this->ipCountry = isset($data['ip_country']) ? $data['ip_country'] : null;
+        $this->fee = isset($data['fee']) ? $data['fee'] : null;
 
         foreach ($data['history'] as $history) {
             $historyItem = new SubscriptionHistory($history);
@@ -74,5 +75,10 @@ class DetailedSubscription extends SimpleSubscription
      * @var SimpleTransaction[]
      */
     public $transactions = [];
+
+    /**
+     * @var int
+     */
+    public $fee = null;
 
 }

--- a/src/API/SubscriptionService.php
+++ b/src/API/SubscriptionService.php
@@ -102,15 +102,19 @@ class SubscriptionService
      * @param $uuid
      * @param int $amount
      * @param string $orderId
+     * @param bool $surchargeEnabled
+     * @param int $surchargeVatRate
      * @return DetailedTransaction
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function createTransactionFromSubscription($uuid, $amount, $orderId) {
+    public function createTransactionFromSubscription($uuid, $amount, $orderId, $surchargeEnabled = false, $surchargeVatRate = 0) {
 
         $json = [
             'data' => [
                 'amount' => $amount,
-                'order_id' => $orderId
+                'order_id' => $orderId,
+                'surcharge_enabled' => $surchargeEnabled,
+                'surcharge_vat_rate' => $surchargeVatRate,
             ],
         ];
 

--- a/src/API/Transaction/DetailedTransaction.php
+++ b/src/API/Transaction/DetailedTransaction.php
@@ -13,6 +13,7 @@ class DetailedTransaction extends SimpleTransaction {
     {
         parent::__construct($data);
 
+        $this->fee = isset($data['fee']) ? $data['fee'] : null;
         $this->expiryYear = isset($data['expiry_year']) ? $data['expiry_year'] :  null;
         $this->expiryMonth = isset($data['expiry_month']) ? $data['expiry_month'] : null;
         $this->cardCountry = isset($data['card_country']) ? $data['card_country'] : null;
@@ -90,5 +91,10 @@ class DetailedTransaction extends SimpleTransaction {
      * @var string
      */
     public $subscriptionUuid;
+    
+    /**
+     * @var int
+     */
+    public $fee = null;
 
 }


### PR DESCRIPTION
Enable the setting of a Surcharge Enabled flag on a transaction/subscription and subsequent payments on a stored card on file.