### PR TITLE
Raise CURLOPT_TIMEOUT to 30

### DIFF
--- a/src/OAuth/Client/Http/CurlHttpClient.php
+++ b/src/OAuth/Client/Http/CurlHttpClient.php
@@ -89,7 +89,7 @@ class CurlHttpClient implements HttpClientInterface
         $defaultCurlOptions = [
             CURLOPT_HEADER => false,
             CURLOPT_CONNECTTIMEOUT => 5,
-            CURLOPT_TIMEOUT => 10,
+            CURLOPT_TIMEOUT => 30,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FOLLOWLOCATION => false,
             CURLOPT_PROTOCOLS => $this->allowHttp ? CURLPROTO_HTTPS | CURLPROTO_HTTP : CURLPROTO_HTTPS,


### PR DESCRIPTION
Some acquirers take longer than 10 seconds to process