### PR TITLE
Add cardMask property to DetailedTransaction

### DIFF
--- a/src/API/Transaction/DetailedTransaction.php
+++ b/src/API/Transaction/DetailedTransaction.php
@@ -18,6 +18,7 @@ class DetailedTransaction extends SimpleTransaction {
         $this->expiryMonth = isset($data['expiry_month']) ? $data['expiry_month'] : null;
         $this->cardCountry = isset($data['card_country']) ? $data['card_country'] : null;
         $this->cardBin = isset($data['card_bin']) ? $data['card_bin'] : null;
+        $this->cardMask = isset($data['card_mask']) ? $data['card_mask'] : null;
         $this->ip = isset($data['ip']) ? $data['ip'] : null;
         $this->ipCountry = isset($data['ip_country']) ? $data['ip_country'] : null;
 
@@ -46,6 +47,11 @@ class DetailedTransaction extends SimpleTransaction {
      * @var string
      */
     public $cardBin;
+
+    /**
+     * @var string
+     */
+    public $cardMask;
 
     /**
      * @var int


### PR DESCRIPTION
This pull request adds support for a new `cardMask` property to the `DetailedTransaction` class. The property is now set from input data if available.

Enhancements to `DetailedTransaction`:

* Added a new public property `cardMask` to the `DetailedTransaction` class, including its PHPDoc annotation.
* Modified the constructor of `DetailedTransaction` to set the `cardMask` property from the provided input data, defaulting to `null` if not present.