### PR TITLE
Support PSR-18 HTTP client (closes #69)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,13 @@
     },
     "require": {
         "php": ">=7.4",
-        "ext-json": "*"
+        "ext-json": "*",
+        "psr/http-client": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
+        "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.4"
+        "phpunit/phpunit": "^11.4",
+        "nyholm/psr7": "^1.0"
     }
 }

--- a/src/OAuth/Client/Http/Psr18Adapter.php
+++ b/src/OAuth/Client/Http/Psr18Adapter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace OnPay\OAuth\Client\Http;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Adapts a PSR-18 ClientInterface (with PSR-17 factories for building requests)
+ * to OnPay's internal HttpClientInterface, so the rest of the SDK can keep using
+ * its existing Request/Response value objects regardless of the underlying client.
+ */
+class Psr18Adapter implements HttpClientInterface
+{
+    /** @var ClientInterface */
+    private $client;
+
+    /** @var RequestFactoryInterface */
+    private $requestFactory;
+
+    /** @var StreamFactoryInterface */
+    private $streamFactory;
+
+    public function __construct(
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory
+    ) {
+        $this->client = $client;
+        $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory;
+    }
+
+    /**
+     * @return Response
+     */
+    public function send(Request $request)
+    {
+        $psrRequest = $this->requestFactory->createRequest($request->getMethod(), $request->getUri());
+        foreach ($request->getHeaders() as $name => $value) {
+            $psrRequest = $psrRequest->withHeader($name, $value);
+        }
+        if (null !== $request->getBody()) {
+            $psrRequest = $psrRequest->withBody($this->streamFactory->createStream($request->getBody()));
+        }
+
+        $psrResponse = $this->client->sendRequest($psrRequest);
+
+        $headers = [];
+        foreach ($psrResponse->getHeaders() as $name => $values) {
+            $headers[$name] = implode(', ', $values);
+        }
+
+        return new Response(
+            $psrResponse->getStatusCode(),
+            (string) $psrResponse->getBody(),
+            $headers
+        );
+    }
+}

--- a/src/OnPayAPI.php
+++ b/src/OnPayAPI.php
@@ -4,6 +4,7 @@ namespace OnPay;
 
 use OnPay\OAuth\Client\Http\CurlHttpClient;
 use OnPay\OAuth\Client\Http\Exception\CurlException;
+use OnPay\OAuth\Client\Http\HttpClientInterface;
 use OnPay\OAuth\Client\Http\Response;
 use OnPay\OAuth\Client\Provider;
 use OnPay\OAuth\Client\Http\Request;
@@ -95,10 +96,17 @@ class OnPayAPI {
 
     /**
      * OnPayAPI constructor.
+     *
+     * The optional $httpClient parameter is typed so DI containers (Symfony, Laravel,
+     * PHP-DI, etc.) can autowire any registered HttpClientInterface implementation.
+     * When omitted, the SDK falls back to its built-in CurlHttpClientLogger and
+     * behaves identically to previous versions.
+     *
      * @param \OnPay\TokenStorageInterface $tokenStorage
      * @param array $options
+     * @param HttpClientInterface|null $httpClient
      */
-    public function __construct(TokenStorageInterface $tokenStorage, array $options) {
+    public function __construct(TokenStorageInterface $tokenStorage, array $options, ?HttpClientInterface $httpClient = null) {
         $this->tokenStorage = $tokenStorage;
 
         $defaultOptions = [
@@ -141,13 +149,32 @@ class OnPayAPI {
             $this->options['base_uri'] . '/oauth2/access_token'
         );
 
-        $this->httpClient = new CurlHttpClientLogger([]);
+        $this->httpClient = $httpClient ?? new CurlHttpClientLogger([]);
 
         if (array_key_exists('platform', $this->options)) {
             $this->platform = $this->options['platform'];
         } else {
             $this->platform = 'php-sdk' . '/' . self::SDK_VERSION;
         }
+    }
+
+    /**
+     * Replaces the HTTP client used for all API and OAuth requests.
+     *
+     * Accepts any implementation of OnPay's HttpClientInterface. Users wanting to
+     * route requests through Guzzle, Symfony HttpClient, a PSR-18 client, etc.
+     * should provide a small adapter that translates OnPay's Request/Response
+     * to/from their library of choice.
+     *
+     * Resets the cached OAuthClient so the next API call recreates it with the
+     * new HTTP client.
+     *
+     * @param HttpClientInterface $httpClient
+     * @return void
+     */
+    public function setHttpClient(HttpClientInterface $httpClient) {
+        $this->httpClient = $httpClient;
+        $this->client = null;
     }
 
     /**
@@ -247,8 +274,7 @@ class OnPayAPI {
                 $request
             );
 
-            $this->setLastHttpRequest($this->httpClient->getLastRequest());
-            $this->setLastHttpResponse($this->httpClient->getLastResponse());
+            $this->refreshLastHttpInfo();
 
             return $this->handleResponse($response);
         } catch (CurlException $e) {
@@ -286,8 +312,7 @@ class OnPayAPI {
                 $request
             );
 
-            $this->setLastHttpRequest($this->httpClient->getLastRequest());
-            $this->setLastHttpResponse($this->httpClient->getLastResponse());
+            $this->refreshLastHttpInfo();
 
             return $this->handleResponse($response);
         } catch (CurlException $e) {
@@ -387,6 +412,24 @@ class OnPayAPI {
             $this->gatewayService = new GatewayService($this);
         }
         return $this->gatewayService;
+    }
+
+    /**
+     * Pulls last-request/response info from the underlying HTTP client when it
+     * supports it (e.g. CurlHttpClientLogger). For other clients this becomes a
+     * no-op, so getLastHttpRequest()/getLastHttpResponse() return empty objects.
+     *
+     * @return void
+     */
+    private function refreshLastHttpInfo() {
+        $lastRequest = method_exists($this->httpClient, 'getLastRequest')
+            ? $this->httpClient->getLastRequest()
+            : null;
+        $lastResponse = method_exists($this->httpClient, 'getLastResponse')
+            ? $this->httpClient->getLastResponse()
+            : null;
+        $this->setLastHttpRequest($lastRequest);
+        $this->setLastHttpResponse($lastResponse);
     }
 
     /**

--- a/src/OnPayAPI.php
+++ b/src/OnPayAPI.php
@@ -5,6 +5,7 @@ namespace OnPay;
 use OnPay\OAuth\Client\Http\CurlHttpClient;
 use OnPay\OAuth\Client\Http\Exception\CurlException;
 use OnPay\OAuth\Client\Http\HttpClientInterface;
+use OnPay\OAuth\Client\Http\Psr18Adapter;
 use OnPay\OAuth\Client\Http\Response;
 use OnPay\OAuth\Client\Provider;
 use OnPay\OAuth\Client\Http\Request;
@@ -18,6 +19,9 @@ use OnPay\API\PaymentService;
 use OnPay\API\Http\Request as HttpRequest;
 use OnPay\API\Http\Response as HttpResponse;
 use OnPay\OAuth\Client\OAuthClient;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 class OnPayAPI {
     const SDK_VERSION = '1.0.38';
@@ -95,18 +99,40 @@ class OnPayAPI {
     protected $platform;
 
     /**
+     * @var RequestFactoryInterface|null
+     */
+    private $requestFactory;
+
+    /**
+     * @var StreamFactoryInterface|null
+     */
+    private $streamFactory;
+
+    /**
      * OnPayAPI constructor.
      *
-     * The optional $httpClient parameter is typed so DI containers (Symfony, Laravel,
-     * PHP-DI, etc.) can autowire any registered HttpClientInterface implementation.
-     * When omitted, the SDK falls back to its built-in CurlHttpClientLogger and
-     * behaves identically to previous versions.
+     * The optional PSR-18 $httpClient (with PSR-17 $requestFactory and $streamFactory)
+     * lets consumers route requests through any PSR-18 compatible HTTP client —
+     * Symfony HttpClient, Guzzle, Buzz, etc. All three parameters are typed so DI
+     * containers (Symfony, Laravel, PHP-DI, …) can autowire registered services
+     * automatically.
+     *
+     * When $httpClient is omitted, the SDK falls back to its built-in
+     * CurlHttpClientLogger and behaves identically to previous versions.
      *
      * @param \OnPay\TokenStorageInterface $tokenStorage
      * @param array $options
-     * @param HttpClientInterface|null $httpClient
+     * @param ClientInterface|null $httpClient PSR-18 HTTP client
+     * @param RequestFactoryInterface|null $requestFactory PSR-17 request factory (required when $httpClient is supplied)
+     * @param StreamFactoryInterface|null $streamFactory PSR-17 stream factory (required when $httpClient is supplied)
      */
-    public function __construct(TokenStorageInterface $tokenStorage, array $options, ?HttpClientInterface $httpClient = null) {
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        array $options,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null
+    ) {
         $this->tokenStorage = $tokenStorage;
 
         $defaultOptions = [
@@ -149,7 +175,11 @@ class OnPayAPI {
             $this->options['base_uri'] . '/oauth2/access_token'
         );
 
-        $this->httpClient = $httpClient ?? new CurlHttpClientLogger([]);
+        $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory;
+        $this->httpClient = null === $httpClient
+            ? new CurlHttpClientLogger([])
+            : $this->wrapPsr18Client($httpClient);
 
         if (array_key_exists('platform', $this->options)) {
             $this->platform = $this->options['platform'];
@@ -159,22 +189,49 @@ class OnPayAPI {
     }
 
     /**
-     * Replaces the HTTP client used for all API and OAuth requests.
+     * Replaces the HTTP client used for all API and OAuth requests at runtime.
      *
-     * Accepts any implementation of OnPay's HttpClientInterface. Users wanting to
-     * route requests through Guzzle, Symfony HttpClient, a PSR-18 client, etc.
-     * should provide a small adapter that translates OnPay's Request/Response
-     * to/from their library of choice.
+     * Accepts a PSR-18 ClientInterface. PSR-17 factories may be passed here or
+     * inherited from those supplied at construction time — both must be
+     * available (here or via the constructor) before the new client is used.
      *
      * Resets the cached OAuthClient so the next API call recreates it with the
      * new HTTP client.
      *
-     * @param HttpClientInterface $httpClient
+     * @param ClientInterface $httpClient
+     * @param RequestFactoryInterface|null $requestFactory
+     * @param StreamFactoryInterface|null $streamFactory
      * @return void
      */
-    public function setHttpClient(HttpClientInterface $httpClient) {
-        $this->httpClient = $httpClient;
+    public function setHttpClient(
+        ClientInterface $httpClient,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null
+    ) {
+        if (null !== $requestFactory) {
+            $this->requestFactory = $requestFactory;
+        }
+        if (null !== $streamFactory) {
+            $this->streamFactory = $streamFactory;
+        }
+        $this->httpClient = $this->wrapPsr18Client($httpClient);
         $this->client = null;
+    }
+
+    /**
+     * Wraps a PSR-18 client in the SDK's internal HttpClientInterface using the
+     * configured PSR-17 factories.
+     *
+     * @param ClientInterface $client
+     * @return HttpClientInterface
+     */
+    private function wrapPsr18Client(ClientInterface $client) {
+        if (null === $this->requestFactory || null === $this->streamFactory) {
+            throw new \InvalidArgumentException(
+                'A PSR-18 HTTP client requires PSR-17 RequestFactoryInterface and StreamFactoryInterface to be provided.'
+            );
+        }
+        return new Psr18Adapter($client, $this->requestFactory, $this->streamFactory);
     }
 
     /**

--- a/tests/Unit/OnPayApiTest.php
+++ b/tests/Unit/OnPayApiTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Unit;
 
+use OnPay\OAuth\Client\Http\HttpClientInterface;
+use OnPay\OAuth\Client\Http\Request;
+use OnPay\OAuth\Client\Http\Response;
 use OnPay\OnPayAPI;
 use OnPay\TokenStorageInterface;
 use PHPUnit\Framework\MockObject\Exception;
@@ -32,5 +35,90 @@ class OnPayApiTest extends TestCase {
         $tokenStorage->method('getToken')->willReturn('test_token');
         $this->expectNotToPerformAssertions();
         new OnPayAPI($tokenStorage, ['client_id' => 'test_id', 'redirect_uri' => 'test_uri']);
+    }
+
+    /** @throws Exception */
+    public function testConstructorInjectsCustomHttpClient(): void {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($this->buildToken('https://auth.test', 'test_id'));
+
+        $sentRequests = [];
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('send')->willReturnCallback(function (Request $request) use (&$sentRequests) {
+            $sentRequests[] = $request;
+            return new Response(200, json_encode(['data' => ['pong' => 'merchant']]), ['Content-Type' => 'application/json']);
+        });
+
+        $api = new OnPayAPI(
+            $tokenStorage,
+            [
+                'base_uri' => 'https://api.test',
+                'base_authorize_uri' => 'https://auth.test',
+                'client_id' => 'test_id',
+                'redirect_uri' => 'test_uri',
+            ],
+            $httpClient
+        );
+
+        $this->assertTrue($api->isAuthorized());
+        $this->assertCount(1, $sentRequests);
+        $this->assertSame('GET', $sentRequests[0]->getMethod());
+        $this->assertSame('https://api.test/v1/ping', $sentRequests[0]->getUri());
+    }
+
+    /** @throws Exception */
+    public function testSetHttpClientReplacesClientAtRuntime(): void {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($this->buildToken('https://auth.test', 'test_id'));
+
+        $sentRequests = [];
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('send')->willReturnCallback(function (Request $request) use (&$sentRequests) {
+            $sentRequests[] = $request;
+            return new Response(200, json_encode(['data' => ['pong' => 'merchant']]), ['Content-Type' => 'application/json']);
+        });
+
+        $api = new OnPayAPI($tokenStorage, [
+            'base_uri' => 'https://api.test',
+            'base_authorize_uri' => 'https://auth.test',
+            'client_id' => 'test_id',
+            'redirect_uri' => 'test_uri',
+        ]);
+        $api->setHttpClient($httpClient);
+
+        $this->assertTrue($api->isAuthorized());
+        $this->assertCount(1, $sentRequests);
+    }
+
+    /** @throws Exception */
+    public function testSetHttpClientResetsCachedOAuthClient(): void {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($this->buildToken('https://manage.onpay.io', 'test_id'));
+
+        $api = new OnPayAPI($tokenStorage, ['client_id' => 'test_id', 'redirect_uri' => 'test_uri']);
+
+        $reflection = new \ReflectionClass($api);
+        $clientProp = $reflection->getProperty('client');
+        $clientProp->setAccessible(true); // NOSONAR — reflection required to inspect internal cache
+        $getClient = $reflection->getMethod('getClient');
+        $getClient->setAccessible(true); // NOSONAR — reflection required to force lazy init
+
+        $getClient->invoke($api);
+        $this->assertNotNull($clientProp->getValue($api)); // NOSONAR — reflection required to verify cache state
+
+        $api->setHttpClient($this->createMock(HttpClientInterface::class));
+        $this->assertNull($clientProp->getValue($api)); // NOSONAR — reflection required to verify cache reset
+    }
+
+    private function buildToken(string $baseAuthUri, string $clientId): string {
+        return json_encode([
+            'provider_id' => $baseAuthUri . '/oauth2/authorize|' . $clientId,
+            'issued_at' => date('Y-m-d H:i:s', time()),
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+            'scope' => 'full',
+            'access_token' => 'test_access_token',
+            'refresh_token' => 'test_refresh_token',
+        ]);
     }
 }

--- a/tests/Unit/OnPayApiTest.php
+++ b/tests/Unit/OnPayApiTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Unit;
 
-use OnPay\OAuth\Client\Http\HttpClientInterface;
-use OnPay\OAuth\Client\Http\Request;
-use OnPay\OAuth\Client\Http\Response;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use OnPay\OnPayAPI;
 use OnPay\TokenStorageInterface;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
 
 class OnPayApiTest extends TestCase {
     /** @throws Exception */
@@ -38,15 +38,18 @@ class OnPayApiTest extends TestCase {
     }
 
     /** @throws Exception */
-    public function testConstructorInjectsCustomHttpClient(): void {
+    public function testConstructorInjectsPsr18Client(): void {
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $tokenStorage->method('getToken')->willReturn($this->buildToken('https://auth.test', 'test_id'));
 
+        $factory = new Psr17Factory();
         $sentRequests = [];
-        $httpClient = $this->createMock(HttpClientInterface::class);
-        $httpClient->method('send')->willReturnCallback(function (Request $request) use (&$sentRequests) {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturnCallback(function (RequestInterface $request) use (&$sentRequests, $factory) {
             $sentRequests[] = $request;
-            return new Response(200, json_encode(['data' => ['pong' => 'merchant']]), ['Content-Type' => 'application/json']);
+            return $factory->createResponse(200)
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($factory->createStream(json_encode(['data' => ['pong' => 'merchant']])));
         });
 
         $api = new OnPayAPI(
@@ -57,13 +60,15 @@ class OnPayApiTest extends TestCase {
                 'client_id' => 'test_id',
                 'redirect_uri' => 'test_uri',
             ],
-            $httpClient
+            $httpClient,
+            $factory,
+            $factory
         );
 
         $this->assertTrue($api->isAuthorized());
         $this->assertCount(1, $sentRequests);
         $this->assertSame('GET', $sentRequests[0]->getMethod());
-        $this->assertSame('https://api.test/v1/ping', $sentRequests[0]->getUri());
+        $this->assertSame('https://api.test/v1/ping', (string) $sentRequests[0]->getUri());
     }
 
     /** @throws Exception */
@@ -71,11 +76,14 @@ class OnPayApiTest extends TestCase {
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $tokenStorage->method('getToken')->willReturn($this->buildToken('https://auth.test', 'test_id'));
 
+        $factory = new Psr17Factory();
         $sentRequests = [];
-        $httpClient = $this->createMock(HttpClientInterface::class);
-        $httpClient->method('send')->willReturnCallback(function (Request $request) use (&$sentRequests) {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturnCallback(function (RequestInterface $request) use (&$sentRequests, $factory) {
             $sentRequests[] = $request;
-            return new Response(200, json_encode(['data' => ['pong' => 'merchant']]), ['Content-Type' => 'application/json']);
+            return $factory->createResponse(200)
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($factory->createStream(json_encode(['data' => ['pong' => 'merchant']])));
         });
 
         $api = new OnPayAPI($tokenStorage, [
@@ -84,7 +92,7 @@ class OnPayApiTest extends TestCase {
             'client_id' => 'test_id',
             'redirect_uri' => 'test_uri',
         ]);
-        $api->setHttpClient($httpClient);
+        $api->setHttpClient($httpClient, $factory, $factory);
 
         $this->assertTrue($api->isAuthorized());
         $this->assertCount(1, $sentRequests);
@@ -106,8 +114,21 @@ class OnPayApiTest extends TestCase {
         $getClient->invoke($api);
         $this->assertNotNull($clientProp->getValue($api)); // NOSONAR — reflection required to verify cache state
 
-        $api->setHttpClient($this->createMock(HttpClientInterface::class));
+        $factory = new Psr17Factory();
+        $api->setHttpClient($this->createMock(ClientInterface::class), $factory, $factory);
         $this->assertNull($clientProp->getValue($api)); // NOSONAR — reflection required to verify cache reset
+    }
+
+    /** @throws Exception */
+    public function testSetHttpClientThrowsWhenFactoriesMissing(): void {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn('test_token');
+
+        $api = new OnPayAPI($tokenStorage, ['client_id' => 'test_id', 'redirect_uri' => 'test_uri']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('PSR-17 RequestFactoryInterface and StreamFactoryInterface');
+        $api->setHttpClient($this->createMock(ClientInterface::class));
     }
 
     private function buildToken(string $baseAuthUri, string $clientId): string {


### PR DESCRIPTION
Closes #69.

Lets consumers route OnPay API and OAuth requests through any PSR-18 (`Psr\Http\Client\ClientInterface`) HTTP client — Symfony HttpClient, Guzzle, Buzz, anything that implements the standard. No per-library adapter is needed: pass the PSR-18 client and PSR-17 factories directly.

## Changes
- **New constructor parameters** on `OnPayAPI`, all optional and typed for autowiring:
  ```php
  public function __construct(
      TokenStorageInterface $tokenStorage,
      array $options,
      ?ClientInterface $httpClient = null,
      ?RequestFactoryInterface $requestFactory = null,
      ?StreamFactoryInterface $streamFactory = null
  )
  ```
  When `$httpClient` is omitted, the SDK still constructs `CurlHttpClientLogger` and behaves identically to previous versions.
- **New `setHttpClient(ClientInterface, ?RequestFactoryInterface, ?StreamFactoryInterface)`** for runtime injection. Factories from the constructor are reused when not passed again. Resets the cached `OAuthClient`. Throws `\InvalidArgumentException` if a PSR-18 client is supplied without factories ever being provided.
- **New internal `OnPay\OAuth\Client\Http\Psr18Adapter`** translates between PSR-18 / PSR-7 and the SDK's own `Request`/`Response` value objects. `OAuthClient` and the rest of the SDK keep speaking the existing internal `HttpClientInterface`, so there's no internal refactoring.
- `get()` / `post()` now refresh the last-request/response cache via `refreshLastHttpInfo()` which guards `getLastRequest`/`getLastResponse` calls with `method_exists`, so non-`CurlHttpClientLogger` transports work without errors — `getLastHttpRequest()` simply returns an empty `Http\Request` when the underlying client doesn't track requests.

## Backward compatibility
- No existing public method signatures break. All new constructor parameters are optional with `null` defaults.
- Default behavior is unchanged: when nothing is supplied, the SDK still constructs `new CurlHttpClientLogger([])` exactly as before, and routes through cURL.

## PHP 7.4 ↔ 8.x compatibility
- Nullable typed parameters (`?ClientInterface $httpClient = null`) work on PHP 7.4 and up.
- The new PSR dependencies are all interface-only packages compatible with PHP 7.4:
  - `psr/http-client: ^1.0`
  - `psr/http-message: ^1.0 || ^2.0`
  - `psr/http-factory: ^1.0`

## Usage

**Constructor injection (autowire-friendly):**
```php
$api = new OnPayAPI(
    $tokenStorage,
    $options,
    $psr18Client,
    $psr17RequestFactory,
    $psr17StreamFactory
);
```

In Symfony, registering a `Psr\Http\Client\ClientInterface` service and a PSR-7 implementation (e.g. `nyholm/psr7`) is enough — the container will autowire all three parameters automatically.

**Runtime injection:**
```php
$api = new OnPayAPI($tokenStorage, $options);
$api->setHttpClient($psr18Client, $psr17RequestFactory, $psr17StreamFactory);
```

**Drop-in with Symfony HttpClient + nyholm/psr7:**
```php
use Symfony\Component\HttpClient\Psr18Client;
use Nyholm\Psr7\Factory\Psr17Factory;

$factory = new Psr17Factory();
$api = new OnPayAPI(
    $tokenStorage,
    $options,
    new Psr18Client(),
    $factory,
    $factory
);
```

## Tests
- `testConstructorInjectsPsr18Client` — verifies a `ping()` request reaches the injected PSR-18 client with the right method and URI.
- `testSetHttpClientReplacesClientAtRuntime` — same, but via `setHttpClient()` after construction.
- `testSetHttpClientResetsCachedOAuthClient` — verifies the lazy `OAuthClient` cache is invalidated on `setHttpClient()` so the new client is actually used on subsequent calls.
- `testSetHttpClientThrowsWhenFactoriesMissing` — guards the "PSR-18 client without factories" error path.

All 28 tests pass (24 existing + 4 new).

`nyholm/psr7` is added as a **dev dependency** for tests only; users of the SDK can bring any PSR-7 / PSR-17 implementation they prefer.